### PR TITLE
🌱 chore: bump version to 2.2.7 and update changelog with CLI keymap c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,12 @@ Following semantic versioning principles for consistent and predictable releases
 <!-- --- -->
 
 ---
-## [2.2.6] - 2026-05-06
+## [2.2.7] - 2026-05-07
 
 ### Changed
 - **README.md**: Removed F1-Quick Switch keymap.
 - **README.md**: Added new experimental keymap - Delete Project.
+- **README.md**: Added new experimental keymap - CLI.
 
 ---
 ## [2.2.5] - 2026-05-05

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lynx-keymap-75",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "publisher": "bastndev",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
![Lynx Keymap 75%](https://raw.githubusercontent.com/bastndev/Lynx-Keymap-75/refs/heads/main/public/github/images/banner.webp)

<p align="center">
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_ES.md">Español 🇪🇸</a> |
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_ZH.md">中文 🇨🇳</a> |
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_DE.md">Deutsch 🇩🇪</a> |
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_FR.md">Français 🇫🇷</a> |
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_JA.md">日本語 🇯🇵</a> |
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_KO.md">한국어 🇰🇷</a> |
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_PT.md">Português 🇧🇷</a> |
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_RU.md">Русский 🇷🇺</a> |
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_VI.md">Tiếng Việt 🇻🇳</a> |
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_HI.md">हिन्दी 🇮🇳</a> |
  <a href="https://github.com/bastndev/Lynx-Keymap-75/blob/main/public/docs/README_AR.md">العربية 🇸🇦</a><span>...</span>
</p>

<br>

This pull request updates the extension to version 2.2.7 and documents recent changes to experimental keymaps in the changelog. The main focus is on updating documentation to reflect new features.

Version bump:

* Incremented the extension version from 2.2.6 to 2.2.7 in `package.json` to mark the new release.

Documentation updates:

* Updated `CHANGELOG.md` for version 2.2.7 to add the new experimental CLI keymap and document the removal of the F1-Quick Switch keymap and addition of the Delete Project keymap.…hanges