### PR TITLE
Refactor panel toggle and keybindings to resolve conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
         "key"    : "ctrl+alt+[Backquote]",
         "mac"    : "cmd+alt+[Backquote]",
         "command": "workbench.action.terminal.kill"
-      },      {
+      },{
         "key"    : "ctrl+shift+[Backquote]",
         "mac"    : "cmd+shift+[Backquote]",
         "command": "lynx-keymap.smartNewTerminal"

--- a/package.json
+++ b/package.json
@@ -325,8 +325,8 @@
       
       
       {
-        "key"    : "ctrl+escape",
-        "mac"    : "cmd+escape",
+        "key"    : "ctrl+[Backquote]",
+        "mac"    : "cmd+[Backquote]",
         "command": "workbench.action.toggleMaximizedPanel"
       },
       {
@@ -341,9 +341,9 @@
         "key"    : "ctrl+alt+[Backquote]",
         "mac"    : "cmd+alt+[Backquote]",
         "command": "workbench.action.terminal.kill"
-      },{
-        "key"    : "ctrl+[Backquote]",
-        "mac"    : "cmd+[Backquote]",
+      },      {
+        "key"    : "ctrl+shift+[Backquote]",
+        "mac"    : "cmd+shift+[Backquote]",
         "command": "lynx-keymap.smartNewTerminal"
       },
       


### PR DESCRIPTION
This pull request updates keyboard shortcuts in the `package.json` file to improve consistency and avoid conflicts. The most important changes are grouped below:

Keyboard shortcut updates:

* Changed the shortcut for toggling the maximized panel to use `ctrl+[Backquote]` on Windows/Linux and `cmd+[Backquote]` on Mac, instead of `ctrl+escape`/`cmd+escape`.
* Changed the shortcut for the `lynx-keymap.smartNewTerminal` command to use `ctrl+shift+[Backquote]` on Windows/Linux and `cmd+shift+[Backquote]` on Mac, instead of `ctrl+[Backquote]`/`cmd+[Backquote]`.